### PR TITLE
Create Jenkinsfile

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+  agent any
+
+  stages {
+
+    stage('Clone from Github') {
+      steps {
+        checkout scm
+      }
+    }
+
+    stage('Build Image') {
+      steps {
+        script {
+          app = docker.build("$DOCKER_HUB/${IMAGE_NAME}:${IMAGE_TAG}")
+        }
+
+      }
+    }
+
+    stage('Lacework Vulnerability Scan') {
+      steps {
+        sh "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e LW_ACCESS_TOKEN=${LW_ACCESS_TOKEN} -e LW_ACCOUNT_NAME=${LW_ACCOUNT_NAME} -e IMAGE_NAME=$DOCKER_HUB/${IMAGE_NAME} -e IMAGE_TAG=${IMAGE_TAG} -e FAIL_ONLY_IF_VULNERABILITIES_FIXABLE=true -e LW_SCANNER_SCAN_LIBRARY_PACKAGES=true juliensobrier/lw-scanner-scratch:latest"
+      }
+    }
+
+    stage('Push Image to Registry') {
+      steps {
+        script {
+          docker.withRegistry('https://registry.hub.docker.com', 'docker_hub') {
+            app.push("${IMAGE_TAG}")
+            app.push("latest")
+          }
+        }
+
+      }
+    }
+  }
+
+  environment {
+    LW_ACCESS_TOKEN = credentials('LW_ACCESS_TOKEN')
+    LW_ACCOUNT_NAME = credentials('LW_ACCOUNT_NAME')
+    IMAGE_NAME = 'myimage'
+    IMAGE_TAG = 'mytag'
+  }
+
+}


### PR DESCRIPTION
A simple example of a Jenkins pipeline to build an image locally, scan it, and push to a DockerHub repo. Initial commit pulls inline-scanner container from Julien's Dockerhub repo. This will need to be updated once the image has been put in a Lacework DockerHub repo.