### PR TITLE
Create build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+# get the latest version of lw-scanner
+[ ! -d ./binaries] && mkdir ./binaries
+curl -L https://github.com/lacework/lacework-vulnerability-scanner/releases/latest/download/lw-scanner-linux-amd64 -o ./binaries/lw-scanner-linux-amd64
+chmod a+x ./binaries/lw-scanner-linux-amd64
+
+# build image
+IMAGE_NAME=${1:-"juliensobrier/lw-scanner-scratch"}
+docker build -t $IMAGE_NAME .


### PR DESCRIPTION
Script to build a docker image from scratch. This script pulls the latest version of the inline scanner, makes it executable, then builds the image. The Image Name variable is currently set to Julien's DockerHub repo. This will need to be change to point to the Lacework repo/image-name chosen.