### PR TITLE
Create config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,22 @@
+auth:
+    account_name: MY_ACCOUNT
+    integration_access_token: MY_TOKEN
+logging:
+    log_level: error
+    log_file_directory_path: "/root"
+tags:
+    build_id: dev_build
+    build_plan: dev_machine
+    hostname: localhost.localdomain
+    source: lacework_remote_scanner
+    user: John Smith
+data:
+    data_file_directory: "/root"
+    store_evaluations_in_file: false
+    store_manifest_in_file: false
+    output_format: json
+    save_results_in_platform: false
+version:
+    disable_update_check: true
+scanner:
+    scan_library_packages: true


### PR DESCRIPTION
Optional config file that can be used to configure the inline-scanner container (as opposed to configuring it via environmental variables passed during container run. See Readme for configuration options).