### PR TITLE
feat: Add the lw-scanner to the CDK

### DIFF
--- a/.github/workflows/cdk.yaml
+++ b/.github/workflows/cdk.yaml
@@ -18,3 +18,4 @@ jobs:
           ref: main
           token: ${{ secrets.RELENG_GH_TOKEN }}
           inputs: '{ "owner": "lacework", "repository": "lacework-vulnerability-scanner", "tag": "${{  github.event.release.tag_name }}" }'
+          wait-for-completion: false

--- a/.github/workflows/cdk.yaml
+++ b/.github/workflows/cdk.yaml
@@ -1,0 +1,20 @@
+name: cdk
+
+on:
+  release:
+    action: released
+
+jobs:
+  deploy:
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+    steps:
+      - name: Deploy to production CDK
+        uses: aurelien-baudet/workflow-dispatch@v2
+        with:
+          workflow: cdk-ingest.yaml
+          repo: lacework/services
+          ref: main
+          token: ${{ secrets.RELENG_GH_TOKEN }}
+          inputs: '{ "owner": "lacework", "repository": "lacework-vulnerability-scanner", "tag": "${{  github.event.release.tag_name }}" }'

--- a/CDK.yaml
+++ b/CDK.yaml
@@ -1,0 +1,13 @@
+name: lw-scanner
+component_type: CLI_COMMAND
+description: Lacework inline scanner
+feature_flag: ""
+private: false
+install_message: >
+  Having installed the 'lw-scanner' component you unlocked a new command:
+  
+    lacework lw-scanner
+
+  This new command will perform an inline scan outside of Lacework.  Further information can be
+  found at https://docs.lacework.net/console/local-scanning-quickstart.
+update_message: ""

--- a/CDK.yaml
+++ b/CDK.yaml
@@ -1,12 +1,13 @@
-name: lw-scanner
+name: vuln-scanner
+binary_name: lw-scanner
 component_type: CLI_COMMAND
 description: Lacework inline scanner
 feature_flag: ""
 private: false
 install_message: >
-  Having installed the 'lw-scanner' component you unlocked a new command:
+  Having installed the 'vuln-scanner' component you unlocked a new command:
   
-    lacework lw-scanner
+    lacework vuln-scanner
 
   This new command will perform an inline scan outside of Lacework.  Further information can be
   found at https://docs.lacework.net/console/local-scanning-quickstart.


### PR DESCRIPTION
# Jira:

https://lacework.atlassian.net/browse/GROW-2603

# Description:

This change will make inline lw-scanner binary available in the Lacework CLI.  We trigger a workflow each time a release is published, and this workflow will pull the release assets into the CDK service.

The `CDK.yaml` at the repository root is used as configuration.